### PR TITLE
Internal ansible exceptions

### DIFF
--- a/.github/workflows/cotea_testing_workflow.yaml
+++ b/.github/workflows/cotea_testing_workflow.yaml
@@ -31,3 +31,4 @@ jobs:
           cd ./src
           python cotea_ok_case.py
           python cotea_ansible_error_case.py
+          python cotea_internal_error_case.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 cotea.egg-info/
 __pycache__/
 dist/
-
+build/
+venv/
+.venv/

--- a/contributing/contr_inv
+++ b/contributing/contr_inv
@@ -1,5 +1,2 @@
-[host1]           
-host1       ansible_host=localhost      ansible_connection=ssh      ansible_ssh_port=2223      ansible_user=root      ansible_password=veronika
-
-[targets]
-host1
+[host1]
+localhost ansible_connection=ssh ansible_ssh_port=2222 ansible_user=root ansible_password=veronika ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,9 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
+install_requires =
+    ansible >=2.9.4
 
 [options.packages.find]
 where = src

--- a/src/cotea/ansible_execution_sync.py
+++ b/src/cotea/ansible_execution_sync.py
@@ -7,6 +7,8 @@ class ans_sync:
         self.ansible_event = threading.Event()
         self.logger = logger
         self.curr_breakpoint_label = None
+        # Used to pass exceptions from Ansible thread
+        self.exception = None
 
     def status(self):
         self.logger.debug("Runner event status: %s", self.runner_event.is_set())
@@ -17,6 +19,8 @@ class ans_sync:
         #self.logger.debug("runner: waiting...")
         self.runner_event.wait()
         self.runner_event.clear()
+        if self.exception is not None:
+            raise self.exception
 
     def ansible_just_wait(self):
         #self.logger.debug("ansible: waiting...")
@@ -36,6 +40,8 @@ class ans_sync:
         self.runner_event.wait()
         self.runner_event.clear()
         #self.logger.debug("runner: ANSIBLE WAKED ME UP")
+        if self.exception is not None:
+            raise self.exception
 
     def continue_runner(self):
         #self.logger.debug("ansible: resume runner work")

--- a/src/cotea_internal_error_case.py
+++ b/src/cotea_internal_error_case.py
@@ -1,0 +1,66 @@
+import unittest
+
+
+class TestCotea(unittest.TestCase):
+
+    def tearDown(self) -> None:
+        from cotea.utils import remove_modules_from_imported
+
+        # Remove any Ansible-related objects from memory
+        #   to clear previous execution context
+        remove_modules_from_imported(module_name_like="cotea")
+
+    def test_incorrect_playbook_path_case(self):
+        from cotea.runner import runner
+        from cotea.arguments_maker import argument_maker
+
+        pb_path = "cotea_run_files/#%|&"
+        inv_path = "cotea_run_files/inv"
+
+        arg_maker = argument_maker()
+        arg_maker.add_arg("-i", inv_path)
+        r = runner(pb_path, arg_maker, show_progress_bar=True)
+
+        try:
+            while r.has_next_play():
+                while r.has_next_task():
+                    r.run_next_task()
+            r.finish_ansible()
+        except Exception as e:
+            r.finish_ansible()
+            self.assertTrue(hasattr(e, "message"), msg="Exception is expected to have 'message' attribute")
+            self.assertTrue(e.message.startswith(f"the playbook: {pb_path} could not be found"),
+                            msg="Unexpected exception message")
+        else:
+            self.assertFalse(True, msg="Ansible is supposed to fail due to syntax error "
+                                       "and its' exception should be passed to main thread")
+
+    def test_incorrect_syntax_case(self):
+        from cotea.runner import runner
+        from cotea.arguments_maker import argument_maker
+
+        pb_path = "cotea_run_files/incorrect.yaml"
+        inv_path = "cotea_run_files/inv"
+
+        arg_maker = argument_maker()
+        arg_maker.add_arg("-i", inv_path)
+        r = runner(pb_path, arg_maker, show_progress_bar=True)
+
+        try:
+            while r.has_next_play():
+                while r.has_next_task():
+                    r.run_next_task()
+            r.finish_ansible()
+        except Exception as e:
+            r.finish_ansible()
+            # NOTE: e should be AnsibleParserError, but "isinstance" returns False for some reason
+            self.assertTrue(hasattr(e, "message"), msg="Exception is expected to have 'message' attribute")
+            self.assertTrue(e.message.startswith("couldn't resolve module/action"),
+                            msg="Unexpected exception message")
+        else:
+            self.assertFalse(True, msg="Ansible is supposed to fail due to syntax error "
+                                       "and its' exception should be passed to main thread")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cotea_run_files/incorrect.yaml
+++ b/src/cotea_run_files/incorrect.yaml
@@ -1,0 +1,6 @@
+---
+- name: Play1
+  hosts: all
+  tasks:
+  - name: Syntactically incorrect command
+    battle_star_engine:

--- a/src/cotea_run_files/inv
+++ b/src/cotea_run_files/inv
@@ -1,5 +1,2 @@
 [host1]           
-host1       ansible_host=localhost      ansible_connection=ssh      ansible_ssh_port=2222      ansible_user=root      ansible_password=amella
-
-[targets]
-host1
+localhost ansible_connection=ssh ansible_ssh_port=2222 ansible_user=root ansible_password=amella ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'


### PR DESCRIPTION
Added basic exception passing between Ansible and Cotea thread through ans_sync object. 

In case of exception in Ansible thread:
1)  exception is saved as attribute of ans_sync object
2) execution continues in Cotea thread
3) stored exception is raised inside Cotea thread

Added tests for new feature